### PR TITLE
#17 Add additional tests

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,1 +1,4 @@
 DEFAULT_URL_HOST=example
+
+PAIRGURU_BASE_API_URL=https://example.dev/api
+PAIRGURU_BASE_URL=https://example.dev

--- a/app/decorators/movie_decorator.rb
+++ b/app/decorators/movie_decorator.rb
@@ -2,18 +2,24 @@ class MovieDecorator < Draper::Decorator
   delegate_all
 
   def cover
-    URI.join(ENV.fetch('PAIRGURU_BASE_URL'), context['poster'])
+    URI.join(ENV.fetch('PAIRGURU_BASE_URL'), poster)
   end
 
   def rating
-    context['rating']
+    context['rating'] || 0.0
   end
 
   def description
-    context['plot']
+    context['plot'] || ''
   end
 
   def release_date
     object.released_at.to_datetime.strftime('%d-%m-%Y')
+  end
+
+  private
+
+  def poster
+    context['poster'] || ''
   end
 end

--- a/spec/lib/clients/apis/v1/pairguru_spec.rb
+++ b/spec/lib/clients/apis/v1/pairguru_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Clients::Apis::V1::Pairguru do
+  subject { described_class.get_movie_by_title(movie_title) }
+
+  let(:movie_title) { 'Some Title' }
+  let(:failure_class) { Dry::Monads::Result::Failure }
+  let(:success_class) { Dry::Monads::Result::Success }
+  let(:expected_response_code) { 200 }
+  let(:expected_response_body) { { data: {} }.to_json }
+  let(:http_client_return_value) do
+    OpenStruct.new(
+      code: expected_response_code,
+      body: expected_response_body
+    )
+  end
+
+  describe '.get_movie_by_title' do
+    before do
+      allow_any_instance_of(HTTP::Client).to receive(:get).and_return(http_client_return_value)
+    end
+
+    context 'when response code is 200' do
+      let(:expected_response_code) { 200 }
+
+      it { expect(subject).to be_a(success_class) }
+    end
+
+    context 'when response code is not 200' do
+      let(:expected_response_code) { 404 }
+
+      it { expect(subject).to be_a(failure_class) }
+
+      describe 'if response code is 301' do
+        let(:failure_message) { 'Redirect' }
+        let(:expected_response_code) { 301 }
+
+        it 'returns redirect message' do
+          _code, message = subject.failure
+
+          expect(message).to eq(failure_message)
+        end
+      end
+
+      describe 'if response code is 401' do
+        let(:failure_message) { 'Unauthorized' }
+        let(:expected_response_code) { 401 }
+
+        it 'returns unauthorized message' do
+          _code, message = subject.failure
+
+          expect(message).to eq(failure_message)
+        end
+      end
+
+      describe 'if response code is 429' do
+        let(:failure_message) { 'Rate limit exceeded' }
+        let(:expected_response_code) { 429 }
+
+        it 'returns rate limit exceeded message' do
+          _code, message = subject.failure
+
+          expect(message).to eq(failure_message)
+        end
+      end
+
+      describe 'if response code is 404' do
+        let(:failure_message) { 'Invalid request' }
+        let(:expected_response_code) { 404 }
+
+        it 'returns invalid request message' do
+          _code, message = subject.failure
+
+          expect(message).to eq(failure_message)
+        end
+      end
+
+      describe 'if response code is 500' do
+        let(:failure_message) { 'Server error' }
+        let(:expected_response_code) { 500 }
+
+        it 'returns server error message' do
+          _code, message = subject.failure
+
+          expect(message).to eq(failure_message)
+        end
+      end
+
+      describe 'if response code is 1000' do
+        let(:failure_message) { 'Unknown error' }
+        let(:expected_response_code) { 1000 }
+
+        it 'returns unknown error message' do
+          _code, message = subject.failure
+
+          expect(message).to eq(failure_message)
+        end
+      end
+    end
+
+    context 'when cconnection failed' do
+      let(:failure_message) { 'Could not fetch data from external service' }
+
+      context 'when HTTP::ConnectionError occurred' do
+        before do
+          allow_any_instance_of(HTTP::Client).to receive(:get).and_raise(HTTP::ConnectionError)
+        end
+
+        it { expect(subject).to be_a(failure_class) }
+        it { expect(subject.failure).to eq(failure_message) }
+      end
+
+      context 'when HTTP::TimeoutError occurred' do
+        before do
+          allow_any_instance_of(HTTP::Client).to receive(:get).and_raise(HTTP::TimeoutError)
+        end
+
+        it { expect(subject).to be_a(failure_class) }
+        it { expect(subject.failure).to eq(failure_message) }
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/movies_spec.rb
+++ b/spec/requests/api/v1/movies_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 describe 'API V1 Movies', type: :request do
   let(:action_genre) { create(:genre) }
   let(:action_genre_movies) { action_genre.movies }
+
   let!(:kill_bill_vol_1_movie) { create(:movie, title: 'Kill Bill vol. 1', genre: action_genre) }
   let!(:kill_bill_vol_2_movie) { create(:movie, title: 'Kill Bill vol. 2', genre: action_genre) }
 
@@ -84,6 +85,20 @@ describe 'API V1 Movies', type: :request do
 
       it 'returns included genres' do
         expect(json_response['included']).to include_json(expected_included_json)
+      end
+    end
+
+    context 'when record not found' do
+      before { get '/api/v1/movies/1000' }
+
+      let(:expected_error_json) do
+        {
+          'error': 'resource_not_found'
+        }
+      end
+
+      it 'returns error message' do
+        expect(json_response).to include_json(expected_error_json)
       end
     end
   end

--- a/spec/requests/genres_spec.rb
+++ b/spec/requests/genres_spec.rb
@@ -1,11 +1,29 @@
 require 'rails_helper'
 
 describe 'Genres requests', type: :request do
-  let!(:genres) { create_list(:genre, 5, :with_movies) }
+  before do
+    allow(Clients::Apis::V1::Pairguru).to receive(:get_movie_by_title).and_return(
+      Dry::Monads::Result::Success.new(
+        [200, { 'attributes' => {
+          'poster' => expected_image_path,
+          'rating' => expected_rating,
+          'plot' => expected_description
+        } }]
+      )
+    )
+  end
 
   describe 'genre list' do
+    let!(:genres) { create_list(:genre, 5, :with_movies) }
+    let(:expected_rating) { '3.0' }
+    let(:expected_image_path) { '/random.jpg' }
+    let(:expected_description) { 'Very long description' }
+
     it 'displays only related movies' do
       visit '/genres/' + genres.sample.id.to_s + '/movies'
+
+      expect(page).to have_text("Rating: #{expected_rating}")
+      expect(page).to have_text(expected_description)
       expect(page).to have_selector('table tr', count: 5)
     end
   end

--- a/spec/requests/movies_spec.rb
+++ b/spec/requests/movies_spec.rb
@@ -1,10 +1,33 @@
 require 'rails_helper'
 
 describe 'Movies requests', type: :request do
+  before do
+    allow(Clients::Apis::V1::Pairguru).to receive(:get_movie_by_title).and_return(
+      Dry::Monads::Result::Success.new(
+        [200, { 'attributes' => {
+          'poster' => expected_image_path,
+          'rating' => expected_rating,
+          'plot' => expected_description
+        } }]
+      )
+    )
+  end
+
   describe 'movies list' do
+    let(:genre) { create(:genre) }
+    let!(:movie) { create(:movie, genre: genre).decorate }
+    let(:expected_rating) { '2.0' }
+    let(:expected_image_path) { '/random.jpg' }
+    let(:expected_description) { 'Very long description' }
+
     it 'displays right title' do
       visit '/movies'
+
       expect(page).to have_selector('h1', text: 'Movies')
+      expect(page).to have_text("Released: #{movie.release_date}")
+      expect(page).to have_text("Rating: #{expected_rating}")
+      expect(page).to have_text(expected_description)
+      expect(find('.img-rounded')[:src]).to eq("https://example.dev#{expected_image_path}")
     end
   end
 end

--- a/spec/services/decorate_movie_with_external_informations_spec.rb
+++ b/spec/services/decorate_movie_with_external_informations_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe DecorateMovieWithExternalInformations do
+  subject { described_class.call(movie) }
+
+  before do
+    allow(Clients::Apis::V1::Pairguru).to receive(:get_movie_by_title).and_return(client_return_result)
+  end
+
+  let(:movie) { create(:movie) }
+
+  describe '.call' do
+    context 'when movie was not found in pairguru api' do
+      let(:expected_cover) { URI.parse('https://example.dev') }
+      let(:expected_rating) { 0.0 }
+      let(:expected_description) { '' }
+      let(:client_return_result) do
+        Dry::Monads::Result::Failure.new(
+          [404, 'Invalid request']
+        )
+      end
+
+      it 'returns movie object with default values' do
+        expect(subject).to have_attributes(
+          cover: URI.parse('https://example.dev'),
+          description: '',
+          rating: 0.0
+        )
+        expect(subject).to have_attributes(
+          cover: expected_cover,
+          description: expected_description,
+          rating: expected_rating
+        )
+      end
+    end
+
+    context 'when movie was found in pairguru api' do
+      let(:expected_image_path) { '/random.png' }
+      let(:expected_cover) { URI.parse('https://example.dev/random.png') }
+      let(:expected_rating) { 10.0 }
+      let(:expected_description) { 'Very long description' }
+      let(:client_return_result) do
+        Dry::Monads::Result::Success.new(
+          [200, { 'attributes' => {
+            'poster' => expected_image_path,
+            'rating' => expected_rating,
+            'plot' => expected_description
+          } }]
+        )
+      end
+
+      it 'returns movie object with data from pairguru api' do
+        expect(subject).to have_attributes(
+          cover: expected_cover,
+          description: expected_description,
+          rating: expected_rating
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add to Pairguru API Client tests for HTTP codes and exceptions.

Add to movie decorator service tests for result validation.

Decorator should return decorated movie object if we find movie data in external database or not.

In case movie will not be found, decorator should use empty strings for now. Latter on, we can define better defaults.

Add to API requests tests covering error message.

Add to movie and genre request tests, checking if response contain movie values taken from decorator.